### PR TITLE
데몬쓰레드 일시정지 질문

### DIFF
--- a/src/week3/day11/Shell.java
+++ b/src/week3/day11/Shell.java
@@ -72,7 +72,6 @@ public class Shell {
 
     if (flag.equals("-q")) {
       clockThread.interrupt();
-
     }
   }
 


### PR DESCRIPTION
시계를 출력하는 데몬쓰레드를 일시정지할 때,
메인쓰레드에서 데몬쓰레드.Interrupt()밖에 방법이 없는지..?